### PR TITLE
[Controller] Move `_process_output` to SQL Client

### DIFF
--- a/controller/src/controller/db/client.py
+++ b/controller/src/controller/db/client.py
@@ -706,27 +706,3 @@ class Client(ABC):
         :return: The list of chat sessions.
         """
         pass
-
-    def _process_output(
-        self,
-        items,
-        obj_class,
-        mode: api_models.OutputMode = api_models.OutputMode.DETAILS,
-    ) -> Union[list, dict]:
-        """
-        Process the output of a query. Use this method to convert the output to the desired format.
-        For example when listing.
-
-        :param items:     The items to process.
-        :param obj_class: The class of the items.
-        :param mode:      The output mode.
-
-        :return: The processed items.
-        """
-        if mode == api_models.OutputMode.NAMES:
-            return [item.name for item in items]
-        items = [self._from_db_object(item, obj_class) for item in items]
-        if mode == api_models.OutputMode.DETAILS:
-            return items
-        short = mode == api_models.OutputMode.SHORT
-        return [item.to_dict(short=short) for item in items]

--- a/controller/src/controller/db/sql/sqlclient.py
+++ b/controller/src/controller/db/sql/sqlclient.py
@@ -1360,3 +1360,27 @@ class SqlClient(Client):
         if last > 0:
             query = query.limit(last)
         return self._process_output(query.all(), api_models.ChatSession, output_mode)
+
+    def _process_output(
+        self,
+        items,
+        obj_class,
+        mode: api_models.OutputMode = api_models.OutputMode.DETAILS,
+    ) -> Union[list, dict]:
+        """
+        Process the output of a query. Use this method to convert the output to the desired format.
+        For example when listing.
+
+        :param items:     The items to process.
+        :param obj_class: The class of the items.
+        :param mode:      The output mode.
+
+        :return: The processed items.
+        """
+        if mode == api_models.OutputMode.NAMES:
+            return [item.name for item in items]
+        items = [self._to_schema_object(item, obj_class) for item in items]
+        if mode == api_models.OutputMode.DETAILS:
+            return items
+        short = mode == api_models.OutputMode.SHORT
+        return [item.to_dict(short=short) for item in items]

--- a/genai_factory/src/genai_factory/__main__.py
+++ b/genai_factory/src/genai_factory/__main__.py
@@ -20,9 +20,9 @@ import pathlib
 
 import click
 import dotenv
-from genai_factory.api import router
 
 from genai_factory import WorkflowServerConfig
+from genai_factory.api import router
 
 # Load the environment variables:
 dotenv.load_dotenv(os.environ.get("GENAI_FACTORY_ENV_PATH", "./.env"))

--- a/genai_factory/src/genai_factory/workflows/workflow_server.py
+++ b/genai_factory/src/genai_factory/workflows/workflow_server.py
@@ -15,6 +15,7 @@
 from urllib.parse import urlparse
 
 import uvicorn
+
 from genai_factory.config import WorkflowServerConfig
 from genai_factory.controller_client import ControllerClient
 from genai_factory.schemas import WorkflowType


### PR DESCRIPTION
This resolves the list sessions error and all the functions that use `process_outputs`. This function was implemented in the base client class but used a non-abstract method, which failed the API calls.